### PR TITLE
Prevent XLinkWrapper from errantly reinitializing XLink

### DIFF
--- a/src/xlink/xlink_wrapper.cpp
+++ b/src/xlink/xlink_wrapper.cpp
@@ -589,10 +589,16 @@ bool XLinkWrapper::initXLink(
     XLinkGlobalHandler_t* global_handler
 ) const
 {
+    static bool initiated = false;
+    if( initiated ) {
+        if (_be_verbose) { printf("XLink already initialized.\n"); }
+        return true;
+    }
     auto status = XLinkInitialize(global_handler);
     if (X_LINK_SUCCESS == status)
     {
         if (_be_verbose) { printf("XLink initialized.\n"); }
+        initiated = true;
         return true;
     }
     else


### PR DESCRIPTION
Creating multiple depthai devices caused XLink to be reinitialized, invalidating prior device resources.