### PR TITLE
Fetching USB speed and Myriad X serial number

### DIFF
--- a/include/depthai-shared/xlink/xlink_wrapper.hpp
+++ b/include/depthai-shared/xlink/xlink_wrapper.hpp
@@ -69,7 +69,7 @@ public:
      * after connection is succesfully established 
      * and get the string value of the enum to return
      */ 
-    std::string getUSBSpeed(); 
+    UsbSpeed_t getUSBSpeed(); 
     
     /**
      * fetch the Mx serial id from the XLink 

--- a/include/depthai-shared/xlink/xlink_wrapper.hpp
+++ b/include/depthai-shared/xlink/xlink_wrapper.hpp
@@ -20,7 +20,7 @@
 #define MAX_USB_BUFF (5 * 1024 * 1024)
 
 ///
-/// XLinkWrapper is class that wraps XLinks communication.
+/// XLinkWrapper is class that wraps  XLinks communication.
 /// This class uses two mutexes, so be careful editing the code.
 /// It can be used for both side communication (in/out):
 /// 
@@ -50,6 +50,7 @@ public:
     bool initFromHostSide   (
         XLinkGlobalHandler_t* global_handler,
         XLinkHandler_t* device_handler,
+        std::string& usb_speed,
         const std::string &path_to_mvcmd = "",
         const std::string &usb_device = "",
         bool reboot_device_on_destructor = true
@@ -58,6 +59,7 @@ public:
     bool initFromHostSide(
         XLinkGlobalHandler_t* global_handler,
         XLinkHandler_t* device_handler,
+        std::string& usb_speed,
         uint8_t* binary,
         long binary_size,
         const std::string &usb_device,

--- a/include/depthai-shared/xlink/xlink_wrapper.hpp
+++ b/include/depthai-shared/xlink/xlink_wrapper.hpp
@@ -47,7 +47,7 @@ public:
     void setWatchdogUpdateFunction(std::function<void(void)> func);
 
 #ifdef __PC__
-    bool initFromHostSide   (
+    bool initFromHostSide(
         XLinkGlobalHandler_t* global_handler,
         XLinkHandler_t* device_handler,
         std::string& usb_speed,
@@ -55,7 +55,7 @@ public:
         const std::string &path_to_mvcmd = "",
         const std::string &usb_device = "",
         bool reboot_device_on_destructor = true
-        );
+    );
 
     bool initFromHostSide(
         XLinkGlobalHandler_t* global_handler,

--- a/include/depthai-shared/xlink/xlink_wrapper.hpp
+++ b/include/depthai-shared/xlink/xlink_wrapper.hpp
@@ -51,6 +51,7 @@ public:
         XLinkGlobalHandler_t* global_handler,
         XLinkHandler_t* device_handler,
         std::string& usb_speed,
+        std::string& mx_serial,
         const std::string &path_to_mvcmd = "",
         const std::string &usb_device = "",
         bool reboot_device_on_destructor = true
@@ -60,6 +61,7 @@ public:
         XLinkGlobalHandler_t* global_handler,
         XLinkHandler_t* device_handler,
         std::string& usb_speed,
+        std::string& mx_serial,
         uint8_t* binary,
         long binary_size,
         const std::string &usb_device,

--- a/include/depthai-shared/xlink/xlink_wrapper.hpp
+++ b/include/depthai-shared/xlink/xlink_wrapper.hpp
@@ -77,6 +77,8 @@ public:
      */
     std::string getMxSerial();
 
+    XLinkError_t connect(XLinkHandler_t* handler);
+
 
 #endif // __PC__
 #ifndef __PC__
@@ -118,7 +120,7 @@ private:
     const unsigned         c_stream_read_timeout_ms = 500;
     const unsigned         c_stream_read_wait_ms = 1;
     const unsigned         c_stream_read_thread_wait_ms = 1;
-
+    std::mutex mtx;
 
     const bool             _be_verbose;
 #ifdef __PC__

--- a/include/depthai-shared/xlink/xlink_wrapper.hpp
+++ b/include/depthai-shared/xlink/xlink_wrapper.hpp
@@ -76,8 +76,8 @@ public:
      * after connection is succesfully established
      */
     std::string getMxSerial();
-
-    XLinkError_t connect(XLinkHandler_t* handler);
+    
+    XLinkError_t XLinkConnectSafe(XLinkHandler_t* handler);
 
 
 #endif // __PC__

--- a/include/depthai-shared/xlink/xlink_wrapper.hpp
+++ b/include/depthai-shared/xlink/xlink_wrapper.hpp
@@ -43,15 +43,13 @@ class XLinkWrapper
 public:
     XLinkWrapper(bool be_verbose);
     virtual ~XLinkWrapper();
-
+    
     void setWatchdogUpdateFunction(std::function<void(void)> func);
 
 #ifdef __PC__
     bool initFromHostSide(
         XLinkGlobalHandler_t* global_handler,
         XLinkHandler_t* device_handler,
-        std::string& usb_speed,
-        std::string& mx_serial,
         const std::string &path_to_mvcmd = "",
         const std::string &usb_device = "",
         bool reboot_device_on_destructor = true
@@ -60,13 +58,26 @@ public:
     bool initFromHostSide(
         XLinkGlobalHandler_t* global_handler,
         XLinkHandler_t* device_handler,
-        std::string& usb_speed,
-        std::string& mx_serial,
         uint8_t* binary,
         long binary_size,
         const std::string &usb_device,
         bool reboot_device_on_destructor
     );
+
+    /**
+     * fetching the usb speed enum from the XLink 
+     * after connection is succesfully established 
+     * and get the string value of the enum to return
+     */ 
+    std::string getUSBSpeed(); 
+    
+    /**
+     * fetch the Mx serial id from the XLink 
+     * after connection is succesfully established
+     */
+    std::string getMxSerial();
+
+
 #endif // __PC__
 #ifndef __PC__
     bool initFromDeviceSide (XLinkGlobalHandler_t* global_handler);

--- a/src/xlink/xlink_wrapper.cpp
+++ b/src/xlink/xlink_wrapper.cpp
@@ -342,7 +342,7 @@ bool XLinkWrapper::initFromHostSide(
 
 std::string XLinkWrapper::getUSBSpeed(){
     assert(_device_link_id != -1);
-    std::vector<std::string> speed_str = {"Unknown", "Low/1.5Mbps", "Full/12Mbps", "High/480Mbps", "Super/5000Mbps"};
+    std::vector<std::string> speed_str = {"Unknown", "Low/1.5Mbps", "Full/12Mbps", "High/480Mbps", "Super/5000Mbps", "Super+/10000Mbps"};
     return speed_str[XLinkGetUSBSpeed(_device_link_id)];
 }
 

--- a/src/xlink/xlink_wrapper.cpp
+++ b/src/xlink/xlink_wrapper.cpp
@@ -183,7 +183,7 @@ bool XLinkWrapper::initFromHostSide(
         // Try to connect to device
         tstart = std::chrono::steady_clock::now();
         do {
-            rc = XLinkConnect(device_handler);
+            rc = XLinkConnect(device_handler, speed);
             if (rc == X_LINK_SUCCESS)
                 break;
             tdiff = std::chrono::steady_clock::now() - tstart;
@@ -193,7 +193,9 @@ bool XLinkWrapper::initFromHostSide(
             printf("Failed to connect to device, err code %d\n", rc);
             break;
         }
+        usb_speed = std::string(speed);
 
+        std::cout << "found speed ehre too : " << usb_speed << std::endl;
         printf("Successfully connected to device.\n");
 
         _device_link_id = device_handler->linkId;
@@ -303,9 +305,8 @@ bool XLinkWrapper::initFromHostSide(
             // Development option, the firmware is loaded via JTAG
             printf("Device boot is skipped. (\"binary to boot from\" NOT SPECIFIED !)\n");
         }
-        printf("~~ ~~ ~~ ~~ ~~ ~~ ~~> After firmware here Speed:%s\n", speed); 
-        usb_speed = std::string(speed);
-        std::cout <<"Here is usb speed as string: " << usb_speed << std::endl;
+        // usb_speed = std::string(speed);
+        // std::cout <<"Here is usb speed as string: " << usb_speed << std::endl;
         printf("firmware sent\n");
         if (!usb_device.empty())
             snprintf(in_deviceDesc.name, sizeof in_deviceDesc.name,
@@ -328,11 +329,10 @@ bool XLinkWrapper::initFromHostSide(
         device_handler->devicePath = deviceDesc.name;
         device_handler->protocol = deviceDesc.protocol;
         
-        printf("In xlink connect\n");
         // Try to connect to device
         tstart = std::chrono::steady_clock::now();
         do {
-            rc = XLinkConnect(device_handler);
+            rc = XLinkConnect(device_handler, speed);
             if (rc == X_LINK_SUCCESS)
                 break;
             tdiff = std::chrono::steady_clock::now() - tstart;
@@ -343,6 +343,7 @@ bool XLinkWrapper::initFromHostSide(
             break;
         }
 
+        usb_speed = std::string(speed);
         printf("Successfully connected to device.\n");
 
         _device_link_id = device_handler->linkId;

--- a/src/xlink/xlink_wrapper.cpp
+++ b/src/xlink/xlink_wrapper.cpp
@@ -179,7 +179,7 @@ bool XLinkWrapper::initFromHostSide(
         // Try to connect to device
         tstart = std::chrono::steady_clock::now();
         do {
-            rc = connect(device_handler);
+            rc = XLinkConnectSafe(device_handler);
             if (rc == X_LINK_SUCCESS)
                 break;
             tdiff = std::chrono::steady_clock::now() - tstart;
@@ -213,8 +213,6 @@ bool XLinkWrapper::initFromHostSide(
     _reboot_device_on_destructor = reboot_device_on_destructor;
 
     assert(_device_link_id == -1);
-    // variable to copy mriad x serial id and usb speed
-    char dev_conn_info[148] = { 0 }; 
     bool result = false;
     do
     {
@@ -296,7 +294,6 @@ bool XLinkWrapper::initFromHostSide(
             // Development option, the firmware is loaded via JTAG
             printf("Device boot is skipped. (\"binary to boot from\" NOT SPECIFIED !)\n");
         }
-        printf("firmware sent\n");
         if (!usb_device.empty())
             snprintf(in_deviceDesc.name, sizeof in_deviceDesc.name,
                     "%s-", usb_device.c_str());
@@ -321,7 +318,7 @@ bool XLinkWrapper::initFromHostSide(
         // Try to connect to device
         tstart = std::chrono::steady_clock::now();
         do {
-            rc = connect(device_handler);
+            rc = XLinkConnectSafe(device_handler);
             if (rc == X_LINK_SUCCESS)
                 break;
             tdiff = std::chrono::steady_clock::now() - tstart;
@@ -354,7 +351,7 @@ std::string XLinkWrapper::getMxSerial(){
     return std::string(XLinkGetMxSerial(_device_link_id)); 
 }
 
-XLinkError_t XLinkWrapper::connect(XLinkHandler_t* handler){
+XLinkError_t XLinkWrapper::XLinkConnectSafe(XLinkHandler_t* handler){
     std::unique_lock<std::mutex> lock(mtx);
     return XLinkConnect(handler);
 }

--- a/src/xlink/xlink_wrapper.cpp
+++ b/src/xlink/xlink_wrapper.cpp
@@ -340,10 +340,10 @@ bool XLinkWrapper::initFromHostSide(
     return result;
 }
 
-std::string XLinkWrapper::getUSBSpeed(){
+UsbSpeed_t XLinkWrapper::getUSBSpeed(){
     assert(_device_link_id != -1);
-    std::vector<std::string> speed_str = {"Unknown", "Low/1.5Mbps", "Full/12Mbps", "High/480Mbps", "Super/5000Mbps", "Super+/10000Mbps"};
-    return speed_str[XLinkGetUSBSpeed(_device_link_id)];
+    // std::vector<std::string> speed_str = {"Unknown", "Low/1.5Mbps", "Full/12Mbps", "High/480Mbps", "Super/5000Mbps", "Super+/10000Mbps"};
+    return XLinkGetUSBSpeed(_device_link_id);
 }
 
 std::string XLinkWrapper::getMxSerial(){

--- a/src/xlink/xlink_wrapper.cpp
+++ b/src/xlink/xlink_wrapper.cpp
@@ -148,7 +148,7 @@ bool XLinkWrapper::initFromHostSide(
             }
 
             printf("Sending device firmware \"cmd_file\": %s\n", device_cmd_file.c_str());
-            rc = XLinkBoot(&deviceDesc, device_cmd_file.c_str(), dev_conn_info);
+            rc = XLinkBoot(&deviceDesc, device_cmd_file.c_str());
             if (rc != X_LINK_SUCCESS) {
                 printf("Failed to boot the device: %s, err code %d\n", deviceDesc.name, rc);
                 break;
@@ -157,9 +157,7 @@ bool XLinkWrapper::initFromHostSide(
             // Development option, the firmware is loaded via JTAG
             printf("Device boot is skipped. (\"cmd_file\" NOT SPECIFIED !)\n");
         }
-        // usb_speed = std::string(speed);
 
-        std::cout << "found speed ehre too : " << usb_speed << std::endl;
         if (!usb_device.empty())
             snprintf(in_deviceDesc.name, sizeof in_deviceDesc.name,
                     "%s-", usb_device.c_str());
@@ -202,7 +200,7 @@ bool XLinkWrapper::initFromHostSide(
         mx_serial = std::string(serial_id);
         usb_speed = std::string(speed);
 
-        std::cout << "found speed ehre too : " << usb_speed << std::endl;
+        std::cout << "found speed here too : " << usb_speed << std::endl;
         printf("Successfully connected to device.\n");
 
         _device_link_id = device_handler->linkId;
@@ -228,9 +226,8 @@ bool XLinkWrapper::initFromHostSide(
     _reboot_device_on_destructor = reboot_device_on_destructor;
 
     assert(_device_link_id == -1);
-    char dev_conn_info[148] = { 0 }; //"Dont know--------";
-    // speed = (char[15]){ 0 };
-
+    // variable to copy mriad x serial id and usb speed
+    char dev_conn_info[148] = { 0 }; 
     bool result = false;
     do
     {
@@ -303,8 +300,7 @@ bool XLinkWrapper::initFromHostSide(
                 break;
             }
             printf("Sending internal device firmware\n");
-            printf("~~ ~~ ~~ ~~ ~~ ~~ ~~> before firmware here Speed:%s\n", dev_conn_info); 
-            rc = XLinkBootMemory(&deviceDesc, binary, binary_size, dev_conn_info);
+            rc = XLinkBootMemory(&deviceDesc, binary, binary_size);
             if (rc != X_LINK_SUCCESS) {
                 printf("Failed to boot the device: %s, err code %d\n", deviceDesc.name, rc);
                 break;
@@ -351,14 +347,14 @@ bool XLinkWrapper::initFromHostSide(
             break;
         }
 
-        char speed[15];
+        char speed[15]; 
         char serial_id[128];
-
         strncpy(speed, dev_conn_info, 15);
         strncpy(serial_id, dev_conn_info+15, 128);
 
         printf("got %s and %s\n", speed, serial_id );
 
+        // copying usb speed and mx_serial
         usb_speed = std::string(speed);
         mx_serial = std::string(serial_id);
         printf("Successfully connected to device.\n");
@@ -483,7 +479,7 @@ uint32_t XLinkWrapper::openReadAndCloseStream(
 
 
 
-// TODO: unite code: reading from stream
+        // TODO: unite code: reading from stream
         streamPacketDesc_t * packet = nullptr;
         XLinkError_t status = XLinkReadData(stream_id, &packet);
 

--- a/src/xlink/xlink_wrapper.cpp
+++ b/src/xlink/xlink_wrapper.cpp
@@ -344,12 +344,14 @@ bool XLinkWrapper::initFromHostSide(
 }
 
 std::string XLinkWrapper::getUSBSpeed(){
+    assert(_device_link_id != -1);
     std::vector<std::string> speed_str = {"Unknown", "Low/1.5Mbps", "Full/12Mbps", "High/480Mbps", "Super/5000Mbps"};
-    return speed_str[XLinkGetUSBSpeed()];
+    return speed_str[XLinkGetUSBSpeed(_device_link_id)];
 }
 
 std::string XLinkWrapper::getMxSerial(){
-    return std::string(XLinkGetMxSerial()); 
+    assert(_device_link_id != -1);
+    return std::string(XLinkGetMxSerial(_device_link_id)); 
 }
 
 #endif // __PC__

--- a/src/xlink/xlink_wrapper.cpp
+++ b/src/xlink/xlink_wrapper.cpp
@@ -179,7 +179,7 @@ bool XLinkWrapper::initFromHostSide(
         // Try to connect to device
         tstart = std::chrono::steady_clock::now();
         do {
-            rc = XLinkConnect(device_handler);
+            rc = connect(device_handler);
             if (rc == X_LINK_SUCCESS)
                 break;
             tdiff = std::chrono::steady_clock::now() - tstart;
@@ -321,7 +321,7 @@ bool XLinkWrapper::initFromHostSide(
         // Try to connect to device
         tstart = std::chrono::steady_clock::now();
         do {
-            rc = XLinkConnect(device_handler);
+            rc = connect(device_handler);
             if (rc == X_LINK_SUCCESS)
                 break;
             tdiff = std::chrono::steady_clock::now() - tstart;
@@ -352,6 +352,11 @@ std::string XLinkWrapper::getUSBSpeed(){
 std::string XLinkWrapper::getMxSerial(){
     assert(_device_link_id != -1);
     return std::string(XLinkGetMxSerial(_device_link_id)); 
+}
+
+XLinkError_t XLinkWrapper::connect(XLinkHandler_t* handler){
+    std::unique_lock<std::mutex> lock(mtx);
+    return XLinkConnect(handler);
 }
 
 #endif // __PC__


### PR DESCRIPTION
Modified `initFromHostSide` to take `usb_speed` and `mx_serial` strings as arguments(pass by reference) which are private variables of device class. allowing them to be loaded on XLink connection. 