### PR TITLE
FrameMetadata getCameraName(): check for out-of-range instNo

### DIFF
--- a/include/depthai-shared/metadata/frame_metadata.hpp
+++ b/include/depthai-shared/metadata/frame_metadata.hpp
@@ -86,7 +86,9 @@ public:
     }
 
     std::string getCameraName() {
-        const std::string camName[] = {"rgb", "left", "right"};
+        const std::vector<std::string> camName = {"rgb", "left", "right"};
+        if (instNo >= camName.size()) // Likely if instNo not set on device
+            return std::string("INVALID_instNo");
         return camName[instNo];
     }
 


### PR DESCRIPTION
The uninitialized `instNo` metadata field caused `getCameraName()` to possibly segfault.
Adding the check, even though the device side should be fixed now.