### PR TITLE
Gen2 camera improvements

### DIFF
--- a/include/depthai-shared/datatype/DatatypeEnum.hpp
+++ b/include/depthai-shared/datatype/DatatypeEnum.hpp
@@ -4,7 +4,7 @@
 
 namespace dai {
 
-enum class DatatypeEnum : std::int32_t { Buffer, ImgFrame, NNData, ImageManipConfig };
+enum class DatatypeEnum : std::int32_t { Buffer, ImgFrame, NNData, ImageManipConfig, CameraControl };
 bool isDatatypeSubclassOf(DatatypeEnum parent, DatatypeEnum children);
 
 }  // namespace dai

--- a/include/depthai-shared/datatype/RawCameraControl.hpp
+++ b/include/depthai-shared/datatype/RawCameraControl.hpp
@@ -9,11 +9,8 @@
 namespace dai {
 
 struct RawCameraControl : public RawBuffer {
-    
     // TODO(themarpe/alex) - this is a placeholder for vairous camera control commands
     bool captureStill = false;
-
-
 
     void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
         nlohmann::json j = *this;

--- a/include/depthai-shared/datatype/RawCameraControl.hpp
+++ b/include/depthai-shared/datatype/RawCameraControl.hpp
@@ -1,0 +1,27 @@
+#pragma once
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <vector>
+
+#include "DatatypeEnum.hpp"
+#include "RawBuffer.hpp"
+
+namespace dai {
+
+struct RawCameraControl : public RawBuffer {
+    
+    // TODO(themarpe/alex) - this is a placeholder for vairous camera control commands
+    bool captureStill = false;
+
+
+
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+        nlohmann::json j = *this;
+        metadata = nlohmann::json::to_msgpack(j);
+        datatype = DatatypeEnum::CameraControl;
+    };
+
+    NLOHMANN_DEFINE_TYPE_INTRUSIVE(RawCameraControl, captureStill);
+};
+
+}  // namespace dai

--- a/include/depthai-shared/pb/common/CameraBoardSocket.hpp
+++ b/include/depthai-shared/pb/common/CameraBoardSocket.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace dai {
+/**
+ * Which Camera socket to use.
+ *
+ * AUTO denotes that the decision will be made by device
+ */
+enum class CameraBoardSocket : int32_t { AUTO = -1, RGB, LEFT, RIGHT };
+
+}  // namespace dai

--- a/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
@@ -10,6 +10,8 @@ namespace dai {
  * Specify ColorCamera options such as camera ID, ...
  */
 struct ColorCameraProperties {
+    static constexpr int AUTO = -1;
+
     /**
      * Select the camera sensor resolution
      */
@@ -50,22 +52,22 @@ struct ColorCameraProperties {
     /**
      * Preview frame output width
      */
-    int32_t videoWidth = -1;
+    int32_t videoWidth = AUTO;
 
     /**
      * Preview frame output height
      */
-    int32_t videoHeight = -1;
+    int32_t videoHeight = AUTO;
 
     /**
      * Preview frame output width
      */
-    int32_t stillWidth = -1;
+    int32_t stillWidth = AUTO;
 
     /**
      * Preview frame output height
      */
-    int32_t stillHeight = -1;
+    int32_t stillHeight = AUTO;
 
     /**
      * Select the camera sensor resolution
@@ -79,8 +81,8 @@ struct ColorCameraProperties {
     /**
      * Initial sensor crop, -1 signifies center crop
      */
-    float sensorCropX = -1;
-    float sensorCropY = -1;
+    float sensorCropX = AUTO;
+    float sensorCropY = AUTO;
 
     /**
      * Whether to wait for config at 'inputConfig' io

--- a/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
@@ -75,6 +75,12 @@ struct ColorCameraProperties {
      * Camera sensor FPS
      */
     float fps = 30.0;
+
+    /**
+     * Initial sensor crop, -1 signifies center crop
+     */
+    float sensorCropX = -1;
+    float sensorCropY = -1;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties,
@@ -89,6 +95,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties,
                                    stillWidth,
                                    stillHeight,
                                    resolution,
-                                   fps);
+                                   fps,
+                                   sensorCropX,
+                                   sensorCropY);
 
 }  // namespace dai

--- a/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
@@ -81,6 +81,11 @@ struct ColorCameraProperties {
      */
     float sensorCropX = -1;
     float sensorCropY = -1;
+
+    /**
+     * Whether to wait for config at 'inputConfig' io
+     */
+    bool inputConfigSync = false;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties,
@@ -97,6 +102,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties,
                                    resolution,
                                    fps,
                                    sensorCropX,
-                                   sensorCropY);
+                                   sensorCropY,
+                                   inputConfigSync);
 
 }  // namespace dai

--- a/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
@@ -2,6 +2,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include "depthai-shared/pb/common/CameraBoardSocket.hpp"
+
 namespace dai {
 
 /**
@@ -19,9 +21,10 @@ struct ColorCameraProperties {
     enum class ColorOrder : int32_t { BGR, RGB };
 
     /**
-     * Which color camera the node will use
+     * Which socket will color camera use
      */
-    int32_t camId = 0;
+    CameraBoardSocket boardSocket = CameraBoardSocket::AUTO;
+
     /**
      * For 24 bit color these can be either RGB or BGR
      */
@@ -48,7 +51,7 @@ struct ColorCameraProperties {
      * Preview frame output width
      */
     int32_t videoWidth = -1;
-    
+
     /**
      * Preview frame output height
      */
@@ -74,6 +77,18 @@ struct ColorCameraProperties {
     float fps = 30.0;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties, camId, colorOrder, interleaved, fp16, previewHeight, previewWidth, resolution, fps);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties,
+                                   boardSocket,
+                                   colorOrder,
+                                   interleaved,
+                                   fp16,
+                                   previewHeight,
+                                   previewWidth,
+                                   videoWidth,
+                                   videoHeight,
+                                   stillWidth,
+                                   stillHeight,
+                                   resolution,
+                                   fps);
 
 }  // namespace dai

--- a/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
@@ -86,6 +86,11 @@ struct ColorCameraProperties {
      * Whether to wait for config at 'inputConfig' io
      */
     bool inputConfigSync = false;
+
+    /**
+     * Whether to keep aspect ratio of input (video size) or not
+     */
+    bool previewKeepAspectRatio = true;
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties,
@@ -103,6 +108,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties,
                                    fps,
                                    sensorCropX,
                                    sensorCropY,
-                                   inputConfigSync);
+                                   inputConfigSync,
+                                   previewKeepAspectRatio);
 
 }  // namespace dai

--- a/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
@@ -34,6 +34,7 @@ struct ColorCameraProperties {
      * Are values FP16 type (0.0 - 255.0)
      */
     bool fp16 = false;
+
     /**
      * Preview frame output height
      */
@@ -42,6 +43,27 @@ struct ColorCameraProperties {
      * Preview frame output width
      */
     uint32_t previewWidth = 300;
+
+    /**
+     * Preview frame output width
+     */
+    int32_t videoWidth = -1;
+    
+    /**
+     * Preview frame output height
+     */
+    int32_t videoHeight = -1;
+
+    /**
+     * Preview frame output width
+     */
+    int32_t stillWidth = -1;
+
+    /**
+     * Preview frame output height
+     */
+    int32_t stillHeight = -1;
+
     /**
      * Select the camera sensor resolution
      */

--- a/include/depthai-shared/pb/properties/MonoCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/MonoCameraProperties.hpp
@@ -2,6 +2,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include "depthai-shared/pb/common/CameraBoardSocket.hpp"
+
 namespace dai {
 
 /**
@@ -14,9 +16,10 @@ struct MonoCameraProperties {
     enum class SensorResolution : int32_t { THE_720_P, THE_800_P, THE_400_P };
 
     /**
-     * Which mono camera the node will use
+     * Which socket will mono camera use
      */
-    int32_t camId = 1;
+    CameraBoardSocket boardSocket = CameraBoardSocket::AUTO;
+
     /**
      * Select the camera sensor resolution
      */
@@ -27,6 +30,6 @@ struct MonoCameraProperties {
     float fps = 30.0;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MonoCameraProperties, camId, resolution, fps);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MonoCameraProperties, boardSocket, resolution, fps);
 
 }  // namespace dai

--- a/src/datatype/DatatypeEnum.cpp
+++ b/src/datatype/DatatypeEnum.cpp
@@ -21,10 +21,11 @@ struct hash<dai::DatatypeEnum> {
 namespace dai {
 
 const std::unordered_map<DatatypeEnum, std::vector<DatatypeEnum>> hierarchy = {
-    {DatatypeEnum::Buffer, {DatatypeEnum::ImgFrame, DatatypeEnum::NNData, DatatypeEnum::ImageManipConfig}},
+    {DatatypeEnum::Buffer, {DatatypeEnum::ImgFrame, DatatypeEnum::NNData, DatatypeEnum::ImageManipConfig, DatatypeEnum::CameraControl}},
     {DatatypeEnum::ImgFrame, {}},
     {DatatypeEnum::NNData, {}},
-    {DatatypeEnum::ImageManipConfig, {}}};
+    {DatatypeEnum::ImageManipConfig, {}},
+    {DatatypeEnum::CameraControl, {}}};
 
 bool isDatatypeSubclassOf(DatatypeEnum parent, DatatypeEnum children) {
     for(const auto& d : hierarchy.at(parent)) {


### PR DESCRIPTION
 - Added new message type `CameraControl` which will be expanded with additional camera related control commands. For now there is a command for still capturing.
 - Added CameraBoardSocket enum which describes boards physical connectors instead of their IDs
 - Added ColorCamera options to specify initial crop and video and still output sizes