### PR TITLE
Add CameraImageOrientation config to Color/Mono properties

### DIFF
--- a/include/depthai-shared/pb/common/CameraImageOrientation.hpp
+++ b/include/depthai-shared/pb/common/CameraImageOrientation.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace dai {
+/**
+ * Camera sensor image orientation / pixel readout.
+ * This exposes direct sensor settings. 90 or 270 degrees rotation is not available.
+ *
+ * AUTO denotes that the decision will be made by device (e.g. on OAK-1/megaAI: ROTATE_180_DEG).
+ */
+enum class CameraImageOrientation : int32_t { AUTO = -1, NORMAL, HORIZONTAL_MIRROR, VERTICAL_FLIP, ROTATE_180_DEG };
+
+}  // namespace dai

--- a/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/ColorCameraProperties.hpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 
 #include "depthai-shared/pb/common/CameraBoardSocket.hpp"
+#include "depthai-shared/pb/common/CameraImageOrientation.hpp"
 
 namespace dai {
 
@@ -26,6 +27,11 @@ struct ColorCameraProperties {
      * Which socket will color camera use
      */
     CameraBoardSocket boardSocket = CameraBoardSocket::AUTO;
+
+    /**
+     * Camera sensor image orientation / pixel readout
+     */
+    CameraImageOrientation imageOrientation = CameraImageOrientation::AUTO;
 
     /**
      * For 24 bit color these can be either RGB or BGR
@@ -97,6 +103,7 @@ struct ColorCameraProperties {
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(ColorCameraProperties,
                                    boardSocket,
+                                   imageOrientation,
                                    colorOrder,
                                    interleaved,
                                    fp16,

--- a/include/depthai-shared/pb/properties/MonoCameraProperties.hpp
+++ b/include/depthai-shared/pb/properties/MonoCameraProperties.hpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 
 #include "depthai-shared/pb/common/CameraBoardSocket.hpp"
+#include "depthai-shared/pb/common/CameraImageOrientation.hpp"
 
 namespace dai {
 
@@ -21,6 +22,11 @@ struct MonoCameraProperties {
     CameraBoardSocket boardSocket = CameraBoardSocket::AUTO;
 
     /**
+     * Camera sensor image orientation / pixel readout
+     */
+    CameraImageOrientation imageOrientation = CameraImageOrientation::AUTO;
+
+    /**
      * Select the camera sensor resolution
      */
     SensorResolution resolution = SensorResolution::THE_720_P;
@@ -30,6 +36,6 @@ struct MonoCameraProperties {
     float fps = 30.0;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MonoCameraProperties, boardSocket, resolution, fps);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MonoCameraProperties, boardSocket, imageOrientation, resolution, fps);
 
 }  // namespace dai


### PR DESCRIPTION
```
AUTO   // on OAK-1/megaAI: ROTATE_180_DEG, other boards: NORMAL
NORMAL
HORIZONTAL_MIRROR
VERTICAL_FLIP
ROTATE_180_DEG
```