### PR TITLE
Remove build helper for `unordered_map` of `enum class` key

### DIFF
--- a/include/depthai-shared/common/CameraBoardSocket.hpp
+++ b/include/depthai-shared/common/CameraBoardSocket.hpp
@@ -11,14 +11,3 @@ namespace dai {
 enum class CameraBoardSocket : int32_t { AUTO = -1, RGB, LEFT, RIGHT };
 
 }  // namespace dai
-
-namespace std {
-
-template <>
-struct hash<dai::CameraBoardSocket> {
-    std::size_t operator()(const dai::CameraBoardSocket& s) const {
-        using Type = typename underlying_type<dai::CameraBoardSocket>::type;
-        return std::hash<Type>{}(static_cast<Type>(s));
-    }
-};
-}  // namespace std

--- a/src/datatype/DatatypeEnum.cpp
+++ b/src/datatype/DatatypeEnum.cpp
@@ -5,19 +5,6 @@
 #include <unordered_map>
 #include <vector>
 
-// DatatypeEnum hash specialization
-namespace std {
-
-template <>
-struct hash<dai::DatatypeEnum> {
-    std::size_t operator()(const dai::DatatypeEnum& s) const {
-        using Type = typename underlying_type<dai::DatatypeEnum>::type;
-        return std::hash<Type>{}(static_cast<Type>(s));
-    }
-};
-
-}  // namespace std
-
 namespace dai {
 
 const std::unordered_map<DatatypeEnum, std::vector<DatatypeEnum>> hierarchy = {


### PR DESCRIPTION
On some compilers (like AppleClang on macOS), the change here requires the standard to be set to at least C++14. This will be updated in [depthai-core](https://github.com/luxonis/depthai-core).
Discussion here: https://github.com/luxonis/depthai-shared/pull/19#discussion_r630290051