### PR TITLE
Make `datatype::serialize` a const member function

### DIFF
--- a/include/depthai-shared/datatype/RawBuffer.hpp
+++ b/include/depthai-shared/datatype/RawBuffer.hpp
@@ -12,7 +12,7 @@ struct RawBuffer {
     virtual ~RawBuffer() = default;
     std::vector<std::uint8_t> data;
 
-    virtual void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) {
+    virtual void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const {
         (void)metadata;
         datatype = DatatypeEnum::Buffer;
     };

--- a/include/depthai-shared/datatype/RawCameraControl.hpp
+++ b/include/depthai-shared/datatype/RawCameraControl.hpp
@@ -235,7 +235,7 @@ struct RawCameraControl : public RawBuffer {
         return !!(cmdMask & (1ull << (uint8_t)cmd));
     }
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::CameraControl;

--- a/include/depthai-shared/datatype/RawIMUData.hpp
+++ b/include/depthai-shared/datatype/RawIMUData.hpp
@@ -180,7 +180,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(IMUPacket, acceleroMeter, gyroscope, magnetic
 struct RawIMUData : public RawBuffer {
     std::vector<IMUPacket> packets;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::IMUData;

--- a/include/depthai-shared/datatype/RawImageManipConfig.hpp
+++ b/include/depthai-shared/datatype/RawImageManipConfig.hpp
@@ -105,7 +105,7 @@ struct RawImageManipConfig : public RawBuffer {
     bool reusePreviousImage = false;
     bool skipCurrentImage = false;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::ImageManipConfig;

--- a/include/depthai-shared/datatype/RawImgDetections.hpp
+++ b/include/depthai-shared/datatype/RawImgDetections.hpp
@@ -21,7 +21,7 @@ struct ImgDetection {
 struct RawImgDetections : public RawBuffer {
     std::vector<ImgDetection> detections;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::ImgDetections;

--- a/include/depthai-shared/datatype/RawImgFrame.hpp
+++ b/include/depthai-shared/datatype/RawImgFrame.hpp
@@ -60,7 +60,7 @@ struct RawImgFrame : public RawBuffer {
     int sequenceNum;       // increments for each frame
     Timestamp ts;          // generation timestamp
 
-    virtual void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::ImgFrame;

--- a/include/depthai-shared/datatype/RawNNData.hpp
+++ b/include/depthai-shared/datatype/RawNNData.hpp
@@ -48,7 +48,7 @@ struct RawNNData : public RawBuffer {
     std::vector<TensorInfo> tensors;
     unsigned int batchSize;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::NNData;

--- a/include/depthai-shared/datatype/RawSpatialImgDetections.hpp
+++ b/include/depthai-shared/datatype/RawSpatialImgDetections.hpp
@@ -21,7 +21,7 @@ struct SpatialImgDetection : ImgDetection {
 struct RawSpatialImgDetections : public RawBuffer {
     std::vector<SpatialImgDetection> detections;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::SpatialImgDetections;

--- a/include/depthai-shared/datatype/RawSpatialLocationCalculatorConfig.hpp
+++ b/include/depthai-shared/datatype/RawSpatialLocationCalculatorConfig.hpp
@@ -33,7 +33,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SpatialLocationCalculatorConfigData, roi, dep
 struct RawSpatialLocationCalculatorConfig : public RawBuffer {
     std::vector<SpatialLocationCalculatorConfigData> config;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::SpatialLocationCalculatorConfig;

--- a/include/depthai-shared/datatype/RawSpatialLocations.hpp
+++ b/include/depthai-shared/datatype/RawSpatialLocations.hpp
@@ -50,7 +50,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(SpatialLocations, config, depthAverage, depth
 struct RawSpatialLocations : public RawBuffer {
     std::vector<SpatialLocations> spatialLocations;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::SpatialLocationCalculatorData;

--- a/include/depthai-shared/datatype/RawSystemInformation.hpp
+++ b/include/depthai-shared/datatype/RawSystemInformation.hpp
@@ -31,7 +31,7 @@ struct RawSystemInformation : public RawBuffer {
     /// Chip temperatures
     ChipTemperature chipTemperature;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::SystemInformation;

--- a/include/depthai-shared/datatype/RawTracklets.hpp
+++ b/include/depthai-shared/datatype/RawTracklets.hpp
@@ -58,7 +58,7 @@ struct Tracklet {
 struct RawTracklets : public RawBuffer {
     std::vector<Tracklet> tracklets;
 
-    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) override {
+    void serialize(std::vector<std::uint8_t>& metadata, DatatypeEnum& datatype) const override {
         nlohmann::json j = *this;
         metadata = nlohmann::json::to_msgpack(j);
         datatype = DatatypeEnum::Tracklets;


### PR DESCRIPTION
Required for suggestion by @themarpe on https://github.com/luxonis/depthai-core/pull/150
