### PR TITLE
Synchronize ImgFrame types order with FW

### DIFF
--- a/include/depthai-shared/datatype/RawImgFrame.hpp
+++ b/include/depthai-shared/datatype/RawImgFrame.hpp
@@ -7,30 +7,24 @@ namespace dai {
 /// RawImgFrame structure
 struct RawImgFrame : public RawBuffer {
     enum class Type {
-        YUV422i,        // interleaved 8 bit
-        YUV444p,        // planar 4:4:4 format
-        YUV420p,        // planar 4:2:0 format
-        YUV422p,        // planar 8 bit
-        YUV400p,        // 8-bit greyscale
-        RGBA8888,       // RGBA interleaved stored in 32 bit word
-        RGB161616,      // Planar 16 bit RGB data
-        RGB888p,        // Planar 8 bit RGB data
-        BGR888p,        // Planar 8 bit BGR data
-        RGB888i,        // Interleaved 8 bit RGB data
-        BGR888i,        // Interleaved 8 bit BGR data
-        RGBF16F16F16p,  // Planar FP16 RGB data
-        BGRF16F16F16p,  // Planar FP16 BGR data
-        RGBF16F16F16i,  // Interleaved FP16 RGB data
-        BGRF16F16F16i,  // Interleaved FP16 BGR data
-        GRAY8,          // 8 bit grayscale (1 plane)
-        GRAYF16,        // FP16 grayscale (normalized)
-        LUT2,           // 1 bit  per pixel, Lookup table
-        LUT4,           // 2 bits per pixel, Lookup table
-        LUT16,          // 4 bits per pixel, Lookup table
-        RAW16,          // save any raw type (8, 10, 12bit) on 16 bits
-        RAW14,          // 14bit value in 16bit storage
-        RAW12,          // 12bit value in 16bit storage
-        RAW10,          // 10bit value in 16bit storage
+        YUV422i,    // interleaved 8 bit
+        YUV444p,    // planar 4:4:4 format
+        YUV420p,    // planar 4:2:0 format
+        YUV422p,    // planar 8 bit
+        YUV400p,    // 8-bit greyscale
+        RGBA8888,   // RGBA interleaved stored in 32 bit word
+        RGB161616,  // Planar 16 bit RGB data
+        RGB888p,    // Planar 8 bit RGB data
+        BGR888p,    // Planar 8 bit BGR data
+        RGB888i,    // Interleaved 8 bit RGB data
+        BGR888i,    // Interleaved 8 bit BGR data
+        LUT2,       // 1 bit  per pixel, Lookup table (used for graphics layers)
+        LUT4,       // 2 bits per pixel, Lookup table (used for graphics layers)
+        LUT16,      // 4 bits per pixel, Lookup table (used for graphics layers)
+        RAW16,      // save any raw type (8, 10, 12bit) on 16 bits
+        RAW14,      // 14bit value in 16bit storage
+        RAW12,      // 12bit value in 16bit storage
+        RAW10,      // 10bit value in 16bit storage
         RAW8,
         PACK10,  // 10bit packed format
         PACK12,  // 12bit packed format
@@ -39,6 +33,12 @@ struct RawImgFrame : public RawBuffer {
         NV21,
         BITSTREAM,  // used for video encoder bitstream
         HDR,
+        RGBF16F16F16p,  // Planar FP16 RGB data
+        BGRF16F16F16p,  // Planar FP16 BGR data
+        RGBF16F16F16i,  // Interleaved FP16 RGB data
+        BGRF16F16F16i,  // Interleaved FP16 BGR data
+        GRAY8,          // 8 bit grayscale (1 plane)
+        GRAYF16,        // FP16 grayscale (normalized)
         NONE
     };
     struct Specs {


### PR DESCRIPTION
While trying setting GREY8 as ImageManip output it returned error.
ImgFrame types enum is out of sync with FW side.
Grey8 still doesn't work though in ImgManip, but that's something else.