### PR TITLE
Configure XLink chunk size

### DIFF
--- a/include/depthai-shared/properties/GlobalProperties.hpp
+++ b/include/depthai-shared/properties/GlobalProperties.hpp
@@ -37,9 +37,23 @@ struct GlobalProperties {
      * Uri which points to camera tuning blob
      */
     std::string cameraTuningBlobUri;
+
+    /**
+     * Chunk size for splitting device-sent XLink packets, in bytes. A larger value could
+     * increase performance, with 0 disabling chunking. A negative value won't modify the
+     * device defaults - configured per protocol, currently 64*1024 for both USB and Ethernet.
+     */
+    int32_t xlinkChunkSize = -1;
 };
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(
-    GlobalProperties, leonCssFrequencyHz, leonMssFrequencyHz, pipelineName, pipelineVersion, cameraTuningBlobSize, cameraTuningBlobUri, calibData);
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(GlobalProperties,
+                                   leonCssFrequencyHz,
+                                   leonMssFrequencyHz,
+                                   pipelineName,
+                                   pipelineVersion,
+                                   cameraTuningBlobSize,
+                                   cameraTuningBlobUri,
+                                   calibData,
+                                   xlinkChunkSize);
 
 }  // namespace dai


### PR DESCRIPTION
    /**
     * Chunk size for splitting device-sent XLink packets, in bytes. A larger value could
     * increase performance, with 0 disabling chunking. A negative value won't modify the
     * device defaults - configured per protocol, currently 64*1024 for both USB and Ethernet.
     */
    int32_t xlinkChunkSize = -1;