### PR TITLE
Support for OAK-D-Lite

### DIFF
--- a/include/depthai-shared/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/properties/ColorCameraProperties.hpp
@@ -26,7 +26,7 @@ struct ColorCameraProperties {
     /**
      * Select the camera sensor resolution
      */
-    enum class SensorResolution : int32_t { THE_1080_P, THE_4_K, THE_12_MP };
+    enum class SensorResolution : int32_t { THE_1080_P, THE_4_K, THE_12_MP, THE_13_MP };
 
     /**
      * For 24 bit color these can be either RGB or BGR

--- a/include/depthai-shared/properties/MonoCameraProperties.hpp
+++ b/include/depthai-shared/properties/MonoCameraProperties.hpp
@@ -13,9 +13,9 @@ namespace dai {
  */
 struct MonoCameraProperties {
     /**
-     * Select the camera sensor resolution: 1280×720, 1280×800, 640×400
+     * Select the camera sensor resolution: 1280×720, 1280×800, 640×400, 640×480
      */
-    enum class SensorResolution : int32_t { THE_720_P, THE_800_P, THE_400_P };
+    enum class SensorResolution : int32_t { THE_720_P, THE_800_P, THE_400_P, THE_480_P };
 
     /*
      * Initial controls applied to MonoCamera node


### PR DESCRIPTION
Color/MonoCameraProperties: add more resolutions:
- `THE_13_MP` for IMX214
- `THE_480_P` for OV7251