### PR TITLE
fix constant/var truncates to decrease noise

### DIFF
--- a/include/depthai-shared/datatype/RawFeatureTrackerConfig.hpp
+++ b/include/depthai-shared/datatype/RawFeatureTrackerConfig.hpp
@@ -96,13 +96,13 @@ struct RawFeatureTrackerConfig : public RawBuffer {
              * When detected number of features exceeds the maximum in a cell threshold is lowered
              * by multiplying its value with this factor.
              */
-            float decreaseFactor = 0.9;
+            float decreaseFactor = 0.9f;
 
             /**
              * When detected number of features doesn't exceed the maximum in a cell, threshold is increased
              * by multiplying its value with this factor.
              */
-            float increaseFactor = 1.1;
+            float increaseFactor = 1.1f;
             NLOHMANN_DEFINE_TYPE_INTRUSIVE(Thresholds, initialValue, min, max, decreaseFactor, increaseFactor);
         };
 
@@ -171,7 +171,7 @@ struct RawFeatureTrackerConfig : public RawBuffer {
              * the displacement between two refinements is smaller than this value.
              * Decreasing this number increases runtime.
              */
-            float epsilon = 0.01;
+            float epsilon = 0.01f;
 
             /**
              * Feature tracking termination criteria. Optical flow will refine the feature position maximum this many times

--- a/include/depthai-shared/device/PrebootConfig.hpp
+++ b/include/depthai-shared/device/PrebootConfig.hpp
@@ -22,7 +22,7 @@ struct PrebootConfig {
     };
 
     USB usb;
-    tl::optional<uint32_t> watchdogTimeoutMs = device::XLINK_WATCHDOG_TIMEOUT.count();
+    tl::optional<uint32_t> watchdogTimeoutMs = static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::milliseconds>(device::XLINK_WATCHDOG_TIMEOUT).count());
 };
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(PrebootConfig::USB, vid, pid, flashBootedVid, flashBootedPid, maxSpeed);


### PR DESCRIPTION
partial fix luxonis/depthai-core#248

Working towards reducing hundreds of warnings about truncations. This PR and forthcoming PR for `depthai-core` remove many many hundreds of warnings of truncations and mismatched var length/sizes. The goal is to reduce the noise so warnings that need action can be surfaced.