### PR TITLE
Modified docstrings to better work with stubgen

### DIFF
--- a/include/depthai-shared/datatype/RawEdgeDetectorConfig.hpp
+++ b/include/depthai-shared/datatype/RawEdgeDetectorConfig.hpp
@@ -14,14 +14,14 @@ namespace dai {
 struct EdgeDetectorConfigData {
     /**
      * Used for horizontal gradiant computation in 3x3 Sobel filter
-     * Format: 3x3 matrix, 2nd column must be 0
-     * Default: +1 0 -1; +2 0 -2; +1 0 -1
+     * Format - 3x3 matrix, 2nd column must be 0
+     * Default - +1 0 -1; +2 0 -2; +1 0 -1
      */
     std::vector<std::vector<int>> sobelFilterHorizontalKernel;
     /**
      * Used for vertical gradiant computation in 3x3 Sobel filter
-     * Format: 3x3 matrix, 2nd row must be 0
-     * Default: +1 +2 +1; 0 0 0; -1 -2 -1
+     * Format - 3x3 matrix, 2nd row must be 0
+     * Default - +1 +2 +1; 0 0 0; -1 -2 -1
      */
     std::vector<std::vector<int>> sobelFilterVerticalKernel;
 };

--- a/include/depthai-shared/datatype/RawSpatialLocationCalculatorConfig.hpp
+++ b/include/depthai-shared/datatype/RawSpatialLocationCalculatorConfig.hpp
@@ -35,8 +35,8 @@ struct SpatialLocationCalculatorConfigData {
      */
     SpatialLocationCalculatorConfigThresholds depthThresholds;
     /**
-     * Calculation method used to obtain spatial locations.
-     * Average: the average of ROI is used for calculation.
+     * Calculation method used to obtain spatial locations
+     * Average - the average of ROI is used for calculation.
      * Min: the minimum value inside ROI is used for calculation.
      * Max: the maximum value inside ROI is used for calculation.
      * Default: average.

--- a/include/depthai-shared/datatype/RawSpatialLocations.hpp
+++ b/include/depthai-shared/datatype/RawSpatialLocations.hpp
@@ -40,7 +40,7 @@ struct SpatialLocations {
      */
     std::uint32_t depthAveragePixelCount;
     /**
-     *  Spatial coordinates: x,y,z; x,y are the relative positions of the center of ROI to the center of depth map
+     *  Spatial coordinates - x,y,z; x,y are the relative positions of the center of ROI to the center of depth map
      */
     Point3f spatialCoordinates;
 };

--- a/include/depthai-shared/datatype/RawStereoDepthConfig.hpp
+++ b/include/depthai-shared/datatype/RawStereoDepthConfig.hpp
@@ -44,10 +44,13 @@ struct RawStereoDepthConfig : public RawBuffer {
         std::int32_t leftRightCheckThreshold = 10;
 
         /**
-         * Number of fractional bits for subpixel mode.
-         * Valid values: 3,4,5.
-         * Defines the number of fractional disparities: 2^x.
-         * Median filter postprocessing is supported only for 3 fractional bits.
+         * Number of fractional bits for subpixel mode
+         *
+         * Valid values: 3,4,5
+         *
+         * Defines the number of fractional disparities: 2^x
+         *
+         * Median filter postprocessing is supported only for 3 fractional bits
          */
         std::int32_t subpixelFractionalBits = 3;
 
@@ -55,7 +58,7 @@ struct RawStereoDepthConfig : public RawBuffer {
     };
 
     /**
-     * Controls the flow of stereo algorithm: left-right check, subpixel etc.
+     * Controls the flow of stereo algorithm - left-right check, subpixel etc.
      */
     AlgorithmControl algorithmControl;
 
@@ -109,7 +112,7 @@ struct RawStereoDepthConfig : public RawBuffer {
         KernelSize kernelSize = KernelSize::AUTO;
 
         /**
-         * Census transform mask, default: auto, mask is set based on resolution and kernel size.
+         * Census transform mask, default - auto, mask is set based on resolution and kernel size.
          * Disabled for 400p input resolution.
          * Enabled for 720p.
          * 0XA82415 for 5x5 census transform kernel.


### PR DESCRIPTION
Colons `:` and dots `.` seems to throw it off.