### PR TITLE
Config watchdog initial delay

### DIFF
--- a/include/depthai-shared/device/PrebootConfig.hpp
+++ b/include/depthai-shared/device/PrebootConfig.hpp
@@ -24,9 +24,10 @@ struct PrebootConfig {
 
     USB usb;
     tl::optional<uint32_t> watchdogTimeoutMs;
+    tl::optional<uint32_t> watchdogInitialDelayMs;
 };
 
 DEPTHAI_SERIALIZE_EXT(PrebootConfig::USB, vid, pid, flashBootedVid, flashBootedPid, maxSpeed);
-DEPTHAI_SERIALIZE_EXT(PrebootConfig, usb, watchdogTimeoutMs);
+DEPTHAI_SERIALIZE_EXT(PrebootConfig, usb, watchdogTimeoutMs, watchdogInitialDelayMs);
 
 }  // namespace dai

--- a/include/depthai-shared/device/PrebootConfig.hpp
+++ b/include/depthai-shared/device/PrebootConfig.hpp
@@ -23,8 +23,7 @@ struct PrebootConfig {
     };
 
     USB usb;
-    tl::optional<uint32_t> watchdogTimeoutMs =
-        static_cast<uint32_t>(std::chrono::duration_cast<std::chrono::milliseconds>(device::XLINK_WATCHDOG_TIMEOUT).count());
+    tl::optional<uint32_t> watchdogTimeoutMs;
 };
 
 DEPTHAI_SERIALIZE_EXT(PrebootConfig::USB, vid, pid, flashBootedVid, flashBootedPid, maxSpeed);


### PR DESCRIPTION
- Fix an issue with watchdog timeout being overridden to 1.5s for Ethernet case. Normally the device will choose 1.5s for USB, 4s for Ethernet. Might have been a cause for watchdog induced crashes in case of network congestion, but not confirmed.
- Add `watchdogInitialDelayMs` to PrebootConfig, for the host to set optionally and override the device defaults, currently 8s for USB, 15s for Ethernet.