### PR TITLE
Specify minimum nlohmann json version

### DIFF
--- a/include/depthai-shared/utility/Serialization.hpp
+++ b/include/depthai-shared/utility/Serialization.hpp
@@ -13,6 +13,13 @@
 
 #include <nlohmann/json.hpp>
 
+// Check version of nlohmann json
+#if(defined(NLOHMANN_JSON_VERSION_MAJOR) && defined(NLOHMANN_JSON_VERSION_MINOR))
+    #if((NLOHMANN_JSON_VERSION_MAJOR < 3) || ((NLOHMANN_JSON_VERSION_MAJOR == 3) && (NLOHMANN_JSON_VERSION_MINOR < 9)))
+static_assert(0, "DepthAI requires nlohmann library version 3.9.0 or higher");
+    #endif
+#endif
+
 // To not require exceptions for embedded usecases.
 #ifndef __has_feature           // Optional of course.
     #define __has_feature(x) 0  // Compatibility with non-clang compilers.


### PR DESCRIPTION
Fon non-CMake consumption, to provide users with a better error message.
Version 3.9.0 is minimum required for the used nlohmann macros for serialization