### PR TITLE
Fix build error: error: redefinition of 'BOARD_CONFIG_MAGIC1'

### DIFF
--- a/include/depthai-shared/device/BoardConfig.hpp
+++ b/include/depthai-shared/device/BoardConfig.hpp
@@ -7,7 +7,6 @@
 // project
 #include "depthai-shared/common/UsbSpeed.hpp"
 #include "depthai-shared/common/optional.hpp"
-#include "depthai-shared/device/BoardConfig.hpp"
 #include "depthai-shared/utility/Serialization.hpp"
 #include "depthai-shared/xlink/XLinkConstants.hpp"
 


### PR DESCRIPTION
Due to recursive include of the header file itself: `BoardConfig.hpp`

(clang 13, Ubuntu 21.10)