### PR TITLE
init dai::RawImgFrame::Specs::type = NONE

### DIFF
--- a/include/depthai-shared/datatype/RawImgFrame.hpp
+++ b/include/depthai-shared/datatype/RawImgFrame.hpp
@@ -152,7 +152,7 @@ struct RawImgFrame : public RawBuffer {
     }
 
     struct Specs {
-        Type type;
+        Type type = Type::NONE;
         unsigned int width;     // width in pixels
         unsigned int height;    // height in pixels
         unsigned int stride;    // defined as distance in bytes from pix(y,x) to pix(y+1,x)


### PR DESCRIPTION
This is coordinated work for fix luxonis/depthai-core#282
When ImgFrame is default constructed, it has a type of YUV422i because the enum at 0 is `YUV422i`.

full details https://github.com/luxonis/depthai-core/issues/282#issuecomment-1039808395