### PR TITLE
removes unneeded init of `std::string` to `""`

### DIFF
--- a/include/depthai-shared/properties/ScriptProperties.hpp
+++ b/include/depthai-shared/properties/ScriptProperties.hpp
@@ -13,7 +13,7 @@ struct ScriptProperties : PropertiesSerializable<Properties, ScriptProperties> {
     /**
      * Uri which points to actual script
      */
-    std::string scriptUri = "";
+    std::string scriptUri;
 
     /**
      * Name of script


### PR DESCRIPTION
fixes #97
removes the unneeded init of `std::string` to `""`