### PR TITLE
Stereo rectify: Change edge color fill from pixel replication to 0 (black)

### DIFF
--- a/include/depthai-shared/properties/StereoDepthProperties.hpp
+++ b/include/depthai-shared/properties/StereoDepthProperties.hpp
@@ -61,7 +61,7 @@ struct StereoDepthProperties : PropertiesSerializable<Properties, StereoDepthPro
     /**
      * Fill color for missing data at frame edges - grayscale 0..255, or -1 to replicate pixels
      */
-    std::int32_t rectifyEdgeFillColor = -1;
+    std::int32_t rectifyEdgeFillColor = 0;
     /**
      * Input frame width. Optional (taken from MonoCamera nodes if they exist)
      */


### PR DESCRIPTION
To avoid artifacts in stereo matching, due to replicated pixels.
TODO: mask the depth map for invalid pixels in rectified image