### PR TITLE
Add 3A skipping option to reduce CSS CPU usage

### DIFF
--- a/include/depthai-shared/device/BoardConfig.hpp
+++ b/include/depthai-shared/device/BoardConfig.hpp
@@ -22,6 +22,8 @@ constexpr static uint32_t BOARD_CONFIG_MAGIC2 = 0x21ea17e6U;
 struct BoardConfig {
     constexpr static uint32_t SIPP_BUFFER_DEFAULT_SIZE = 18 * 1024;
     constexpr static uint32_t SIPP_DMA_BUFFER_DEFAULT_SIZE = 16 * 1024;
+    constexpr static uint32_t ISP_3A_DEFAULT_MAX_FPS_USB = 30;
+    constexpr static uint32_t ISP_3A_DEFAULT_MAX_FPS_ETHERNET = 20;
 
     /// USB related config
     struct USB {
@@ -69,6 +71,15 @@ struct BoardConfig {
      * Units are bytes.
      */
     uint32_t sippDmaBufferSize = SIPP_DMA_BUFFER_DEFAULT_SIZE;
+
+    /**
+     * Isp 3A max rate (auto focus, auto exposure, auto white balance) for USB.
+     */
+    uint32_t isp3aMaxFpsUsb = ISP_3A_DEFAULT_MAX_FPS_USB;
+    /**
+     * Isp 3A max rate (auto focus, auto exposure, auto white balance) for Ethernet.
+     */
+    uint32_t isp3aMaxFpsEthernet = ISP_3A_DEFAULT_MAX_FPS_ETHERNET;
 
     /// GPIO config
     struct GPIO {
@@ -178,6 +189,8 @@ DEPTHAI_SERIALIZE_EXT(BoardConfig,
                       nonExclusiveMode,
                       camera,
                       sippBufferSize,
-                      sippDmaBufferSize);
+                      sippDmaBufferSize,
+                      isp3aMaxFpsUsb,
+                      isp3aMaxFpsEthernet);
 
 }  // namespace dai

--- a/include/depthai-shared/device/BoardConfig.hpp
+++ b/include/depthai-shared/device/BoardConfig.hpp
@@ -30,6 +30,10 @@ struct BoardConfig {
         uint16_t vid = 0x03e7, pid = 0xf63b;
         uint16_t flashBootedVid = 0x03e7, flashBootedPid = 0xf63d;
         UsbSpeed maxSpeed = UsbSpeed::SUPER;
+        /**
+         * Isp 3A max rate (auto focus, auto exposure, auto white balance) for USB.
+         */
+        uint32_t isp3aMaxFps = ISP_3A_DEFAULT_MAX_FPS_USB;
     };
 
     USB usb;
@@ -43,6 +47,10 @@ struct BoardConfig {
         /// Sets the `TCP_NODELAY` option for XLink TCP sockets (disable Nagle's algorithm),
         /// reducing latency at the expense of a small hit for max throughput. Default is `true`
         bool xlinkTcpNoDelay = true;
+        /**
+         * Isp 3A max rate (auto focus, auto exposure, auto white balance) for Ethernet.
+         */
+        uint32_t isp3aMaxFps = ISP_3A_DEFAULT_MAX_FPS_ETHERNET;
     };
 
     Network network;
@@ -71,15 +79,6 @@ struct BoardConfig {
      * Units are bytes.
      */
     uint32_t sippDmaBufferSize = SIPP_DMA_BUFFER_DEFAULT_SIZE;
-
-    /**
-     * Isp 3A max rate (auto focus, auto exposure, auto white balance) for USB.
-     */
-    uint32_t isp3aMaxFpsUsb = ISP_3A_DEFAULT_MAX_FPS_USB;
-    /**
-     * Isp 3A max rate (auto focus, auto exposure, auto white balance) for Ethernet.
-     */
-    uint32_t isp3aMaxFpsEthernet = ISP_3A_DEFAULT_MAX_FPS_ETHERNET;
 
     /// GPIO config
     struct GPIO {
@@ -166,8 +165,8 @@ struct BoardConfig {
     std::unordered_map<CameraBoardSocket, Camera> camera;
 };
 
-DEPTHAI_SERIALIZE_EXT(BoardConfig::USB, vid, pid, flashBootedVid, flashBootedPid, maxSpeed);
-DEPTHAI_SERIALIZE_EXT(BoardConfig::Network, mtu, xlinkTcpNoDelay);
+DEPTHAI_SERIALIZE_EXT(BoardConfig::USB, vid, pid, flashBootedVid, flashBootedPid, maxSpeed, isp3aMaxFps);
+DEPTHAI_SERIALIZE_EXT(BoardConfig::Network, mtu, xlinkTcpNoDelay, isp3aMaxFps);
 DEPTHAI_SERIALIZE_EXT(BoardConfig::GPIO, mode, direction, level, pull, drive, schmitt, slewFast);
 DEPTHAI_SERIALIZE_EXT(BoardConfig::UART, tmp);
 DEPTHAI_SERIALIZE_EXT(BoardConfig::Camera, name, sensorType, orientation);
@@ -189,8 +188,6 @@ DEPTHAI_SERIALIZE_EXT(BoardConfig,
                       nonExclusiveMode,
                       camera,
                       sippBufferSize,
-                      sippDmaBufferSize,
-                      isp3aMaxFpsUsb,
-                      isp3aMaxFpsEthernet);
+                      sippDmaBufferSize);
 
 }  // namespace dai

--- a/include/depthai-shared/properties/CameraProperties.hpp
+++ b/include/depthai-shared/properties/CameraProperties.hpp
@@ -105,11 +105,13 @@ struct CameraProperties : PropertiesSerializable<Properties, CameraProperties> {
     float fps = 30.0;
 
     /**
-     * Image tuning, 3A rate.
-     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
-     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Default (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Can be overriden by setting explicitly.
+     * Value (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    int imageTuningFpsDenominator = 0;
+    int isp3aFps = -1;
 
     /**
      * Initial sensor crop, -1 signifies center crop
@@ -168,7 +170,7 @@ DEPTHAI_SERIALIZE_EXT(CameraProperties,
                       resolutionWidth,
                       resolutionHeight,
                       fps,
-                      imageTuningFpsDenominator,
+                      isp3aFps,
                       sensorCropX,
                       sensorCropY,
                       previewKeepAspectRatio,

--- a/include/depthai-shared/properties/CameraProperties.hpp
+++ b/include/depthai-shared/properties/CameraProperties.hpp
@@ -106,12 +106,12 @@ struct CameraProperties : PropertiesSerializable<Properties, CameraProperties> {
 
     /**
      * Isp 3A rate (auto focus, auto exposure, auto white balance).
-     * Default (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
-     * Value (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    int isp3aFps = -1;
+    int isp3aFps = 0;
 
     /**
      * Initial sensor crop, -1 signifies center crop

--- a/include/depthai-shared/properties/CameraProperties.hpp
+++ b/include/depthai-shared/properties/CameraProperties.hpp
@@ -105,11 +105,14 @@ struct CameraProperties : PropertiesSerializable<Properties, CameraProperties> {
     float fps = 30.0;
 
     /**
-     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Isp 3A rate (auto focus, auto exposure, auto white balance, camera controls etc.).
      * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
      * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
+     * Note that camera controls will be processed at this rate. E.g. if camera is running at 30 fps, and camera control is sent at every frame,
+     * but 3A fps is set to 15, the camera control messages will be processed at 15 fps rate, which will lead to queueing.
+
      */
     int isp3aFps = 0;
 

--- a/include/depthai-shared/properties/CameraProperties.hpp
+++ b/include/depthai-shared/properties/CameraProperties.hpp
@@ -105,6 +105,13 @@ struct CameraProperties : PropertiesSerializable<Properties, CameraProperties> {
     float fps = 30.0;
 
     /**
+     * Image tuning, 3A rate.
+     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     */
+    int imageTuningFpsDenominator = 0;
+
+    /**
      * Initial sensor crop, -1 signifies center crop
      */
     float sensorCropX = AUTO;
@@ -161,6 +168,7 @@ DEPTHAI_SERIALIZE_EXT(CameraProperties,
                       resolutionWidth,
                       resolutionHeight,
                       fps,
+                      imageTuningFpsDenominator,
                       sensorCropX,
                       sensorCropY,
                       previewKeepAspectRatio,

--- a/include/depthai-shared/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/properties/ColorCameraProperties.hpp
@@ -132,6 +132,13 @@ struct ColorCameraProperties : PropertiesSerializable<Properties, ColorCameraPro
     float fps = 30.0;
 
     /**
+     * Image tuning, 3A rate.
+     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     */
+    int imageTuningFpsDenominator = 0;
+
+    /**
      * Initial sensor crop, -1 signifies center crop
      */
     float sensorCropX = AUTO;
@@ -178,6 +185,7 @@ DEPTHAI_SERIALIZE_EXT(ColorCameraProperties,
                       stillHeight,
                       resolution,
                       fps,
+                      imageTuningFpsDenominator,
                       sensorCropX,
                       sensorCropY,
                       previewKeepAspectRatio,

--- a/include/depthai-shared/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/properties/ColorCameraProperties.hpp
@@ -132,11 +132,14 @@ struct ColorCameraProperties : PropertiesSerializable<Properties, ColorCameraPro
     float fps = 30.0;
 
     /**
-     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Isp 3A rate (auto focus, auto exposure, auto white balance, camera controls etc.).
      * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
      * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
+     * Note that camera controls will be processed at this rate. E.g. if camera is running at 30 fps, and camera control is sent at every frame,
+     * but 3A fps is set to 15, the camera control messages will be processed at 15 fps rate, which will lead to queueing.
+
      */
     int isp3aFps = 0;
 

--- a/include/depthai-shared/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/properties/ColorCameraProperties.hpp
@@ -133,12 +133,12 @@ struct ColorCameraProperties : PropertiesSerializable<Properties, ColorCameraPro
 
     /**
      * Isp 3A rate (auto focus, auto exposure, auto white balance).
-     * Default (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
-     * Value (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    int isp3aFps = -1;
+    int isp3aFps = 0;
 
     /**
      * Initial sensor crop, -1 signifies center crop

--- a/include/depthai-shared/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/properties/ColorCameraProperties.hpp
@@ -132,11 +132,13 @@ struct ColorCameraProperties : PropertiesSerializable<Properties, ColorCameraPro
     float fps = 30.0;
 
     /**
-     * Image tuning, 3A rate.
-     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
-     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Default (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Can be overriden by setting explicitly.
+     * Value (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    int imageTuningFpsDenominator = 0;
+    int isp3aFps = -1;
 
     /**
      * Initial sensor crop, -1 signifies center crop
@@ -185,7 +187,7 @@ DEPTHAI_SERIALIZE_EXT(ColorCameraProperties,
                       stillHeight,
                       resolution,
                       fps,
-                      imageTuningFpsDenominator,
+                      isp3aFps,
                       sensorCropX,
                       sensorCropY,
                       previewKeepAspectRatio,

--- a/include/depthai-shared/properties/MonoCameraProperties.hpp
+++ b/include/depthai-shared/properties/MonoCameraProperties.hpp
@@ -48,6 +48,12 @@ struct MonoCameraProperties : PropertiesSerializable<Properties, MonoCameraPrope
      */
     float fps = 30.0;
     /**
+     * Image tuning, 3A rate.
+     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     */
+    int imageTuningFpsDenominator = 0;
+    /**
      * Frame pool size for the main output, ISP processed
      */
     int numFramesPool = 3;
@@ -61,6 +67,15 @@ struct MonoCameraProperties : PropertiesSerializable<Properties, MonoCameraPrope
     std::vector<dai::FrameEvent> eventFilter = {dai::FrameEvent::READOUT_START};
 };
 
-DEPTHAI_SERIALIZE_EXT(MonoCameraProperties, initialControl, boardSocket, cameraName, imageOrientation, resolution, fps, numFramesPool, numFramesPoolRaw);
+DEPTHAI_SERIALIZE_EXT(MonoCameraProperties,
+                      initialControl,
+                      boardSocket,
+                      cameraName,
+                      imageOrientation,
+                      resolution,
+                      fps,
+                      imageTuningFpsDenominator,
+                      numFramesPool,
+                      numFramesPoolRaw);
 
 }  // namespace dai

--- a/include/depthai-shared/properties/MonoCameraProperties.hpp
+++ b/include/depthai-shared/properties/MonoCameraProperties.hpp
@@ -50,11 +50,14 @@ struct MonoCameraProperties : PropertiesSerializable<Properties, MonoCameraPrope
      */
     float fps = 30.0;
     /**
-     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Isp 3A rate (auto focus, auto exposure, auto white balance, camera controls etc.).
      * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
      * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
+     * Note that camera controls will be processed at this rate. E.g. if camera is running at 30 fps, and camera control is sent at every frame,
+     * but 3A fps is set to 15, the camera control messages will be processed at 15 fps rate, which will lead to queueing.
+
      */
     int isp3aFps = 0;
     /**

--- a/include/depthai-shared/properties/MonoCameraProperties.hpp
+++ b/include/depthai-shared/properties/MonoCameraProperties.hpp
@@ -14,6 +14,8 @@ namespace dai {
  * Specify properties for MonoCamera such as camera ID, ...
  */
 struct MonoCameraProperties : PropertiesSerializable<Properties, MonoCameraProperties> {
+    static constexpr int AUTO = -1;
+
     /**
      * Select the camera sensor resolution: 1280×720, 1280×800, 640×400, 640×480, 1920×1200
      */
@@ -49,12 +51,12 @@ struct MonoCameraProperties : PropertiesSerializable<Properties, MonoCameraPrope
     float fps = 30.0;
     /**
      * Isp 3A rate (auto focus, auto exposure, auto white balance).
-     * Default (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Value (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
      * Can be overriden by setting explicitly.
-     * Value (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Default (0) matches the camera FPS, meaning that 3A is running on each frame.
      * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    int isp3aFps = -1;
+    int isp3aFps = 0;
     /**
      * Frame pool size for the main output, ISP processed
      */

--- a/include/depthai-shared/properties/MonoCameraProperties.hpp
+++ b/include/depthai-shared/properties/MonoCameraProperties.hpp
@@ -48,11 +48,13 @@ struct MonoCameraProperties : PropertiesSerializable<Properties, MonoCameraPrope
      */
     float fps = 30.0;
     /**
-     * Image tuning, 3A rate.
-     * Default (0) matches the camera FPS, meaning that statistics for auto exposure are collected on each frame.
-     * Reducing the rate of 3A reduces the CPU usage on MSS, but also reduces the convergence rate of 3A.
+     * Isp 3A rate (auto focus, auto exposure, auto white balance).
+     * Default (-1) is auto-mode. For USB devices will set 3A fps to maximum 30 fps, for POE devices to maximum 20 fps.
+     * Can be overriden by setting explicitly.
+     * Value (0) matches the camera FPS, meaning that 3A is running on each frame.
+     * Reducing the rate of 3A reduces the CPU usage on CSS, but also increases the convergence rate of 3A.
      */
-    int imageTuningFpsDenominator = 0;
+    int isp3aFps = -1;
     /**
      * Frame pool size for the main output, ISP processed
      */
@@ -67,15 +69,7 @@ struct MonoCameraProperties : PropertiesSerializable<Properties, MonoCameraPrope
     std::vector<dai::FrameEvent> eventFilter = {dai::FrameEvent::READOUT_START};
 };
 
-DEPTHAI_SERIALIZE_EXT(MonoCameraProperties,
-                      initialControl,
-                      boardSocket,
-                      cameraName,
-                      imageOrientation,
-                      resolution,
-                      fps,
-                      imageTuningFpsDenominator,
-                      numFramesPool,
-                      numFramesPoolRaw);
+DEPTHAI_SERIALIZE_EXT(
+    MonoCameraProperties, initialControl, boardSocket, cameraName, imageOrientation, resolution, fps, isp3aFps, numFramesPool, numFramesPoolRaw);
 
 }  // namespace dai


### PR DESCRIPTION
CC: @themarpe whether adding to BoardConfig can break POE with older bootloader?