### PR TITLE
RVC3 misc camera controls, ColorCamera binned full FoV res

### DIFF
--- a/include/depthai-shared/datatype/RawCameraControl.hpp
+++ b/include/depthai-shared/datatype/RawCameraControl.hpp
@@ -432,6 +432,7 @@ struct RawCameraControl : public RawBuffer {
     uint16_t wbColorTemp;    // 1000 .. 12000
     uint8_t lowPowerNumFramesBurst;
     uint8_t lowPowerNumFramesDiscard;
+    std::vector<std::pair<std::string, std::string>> miscControls;
 
     void setCommand(Command cmd, bool value = true) {
         uint64_t mask = 1ull << (uint8_t)cmd;
@@ -480,7 +481,8 @@ struct RawCameraControl : public RawBuffer {
                       chromaDenoise,
                       wbColorTemp,
                       lowPowerNumFramesBurst,
-                      lowPowerNumFramesDiscard);
+                      lowPowerNumFramesDiscard,
+                      miscControls);
 };
 
 }  // namespace dai

--- a/include/depthai-shared/properties/ColorCameraProperties.hpp
+++ b/include/depthai-shared/properties/ColorCameraProperties.hpp
@@ -52,6 +52,12 @@ struct ColorCameraProperties : PropertiesSerializable<Properties, ColorCameraPro
         THE_240X180,
         /// 1280 x 962
         THE_1280X962,
+        /// 2000 × 1500
+        THE_2000X1500,
+        /// 2028 × 1520
+        THE_2028X1520,
+        /// 2104 × 1560
+        THE_2104X1560,
     };
 
     /**


### PR DESCRIPTION
- miscellaneous camera controls, to be documented
- new ColorCamera resolutions for full FoV with binning/scaling:
  - IMX582: 2000 × 1500
  - IMX378/477/577: 2028 × 1520
  - IMX214: 2104 × 1560 